### PR TITLE
Modified language and fixed one issue with TraceAsync vs. Trace

### DIFF
--- a/src/content/docs/serverless-function-monitoring/aws-lambda-monitoring/get-started/compatibility-requirements-aws-lambda-monitoring.mdx
+++ b/src/content/docs/serverless-function-monitoring/aws-lambda-monitoring/get-started/compatibility-requirements-aws-lambda-monitoring.mdx
@@ -34,7 +34,7 @@ older than 3.9.0.
 
 To minimize performance impact, we've taken a different approach with Java and .NET Core. New Relic provides
 [OpenTracing](https://opentracing.io/) SDKs for these runtimes. This approach requires a bit more code to integrate.
-For newer runtimes, such as `dotnet6`, [Trace your .NET Lambda functions with New Relic and OpenTelemetry](/docs/serverless-function-monitoring/aws-lambda-monitoring/opentelemetry/lambda-opentelemetry-dotnet/) is available.
+For newer runtimes, such as .NET 6, [Trace your .NET Lambda functions with New Relic and OpenTelemetry](/docs/serverless-function-monitoring/aws-lambda-monitoring/opentelemetry/lambda-opentelemetry-dotnet/) is available.
 
 For complete Lambda instrumentation, some of our agents included in our Lambda layers depend on a language-specific [AWS SDK](https://aws.amazon.com/tools/#sdk). If an AWS SDK is not used, Lambda data will appear as external service calls in the UI, with minimal detail. In other words, we rely on the AWS SDK to facilitate instrumentation of your function.
 

--- a/src/content/docs/serverless-function-monitoring/aws-lambda-monitoring/opentelemetry/lambda-opentelemetry-dotnet.mdx
+++ b/src/content/docs/serverless-function-monitoring/aws-lambda-monitoring/opentelemetry/lambda-opentelemetry-dotnet.mdx
@@ -25,7 +25,7 @@ This guide assumes you have the following:
 * A .NET Lambda Function. If you don't have one yet, [create one now](https://docs.aws.amazon.com/lambda/latest/dg/lambda-csharp.html).
 
 <Callout variant="important">
-  Enabling X-Ray is no longer needed as far as DisableAwsXRayContextExtraction sets to `true` in AWS OTel .NET SDK for Lambda. More details are described in [AWS OTel .NET SDK for Lambda Readme](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/blob/main/src/OpenTelemetry.Instrumentation.AWSLambda/README.md#instrumentation).
+  Enabling X-Ray is no longer needed, because `DisableAwsXRayContextExtraction` is set to `true` in the AWS OTel .NET SDK for Lambda. More details are described in [AWS OTel .NET SDK for Lambda Readme](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/blob/main/src/OpenTelemetry.Instrumentation.AWSLambda/README.md#instrumentation).
 </Callout>
 
 ## Step 1: Install the layer [#install]
@@ -42,7 +42,7 @@ To install it:
 * AMD64 / X86_64: `arn:aws:lambda:{region}:901920570463:layer:aws-otel-collector-amd64-ver-0-90-1:1`
 * ARM64: `arn:aws:lambda:\<region>:901920570463:layer:aws-otel-collector-arm64-ver-0-90-1:1`
 
-For SAM and CloudFormation templates, add the following to your function's properties.
+For SAM and CloudFormation templates, add the following to your function's properties:
 
 ```yaml
   yourFunctionHere:
@@ -169,7 +169,7 @@ For SAM and CloudFormation templates, add this to your function's properties:
 
 ## Step 4: Instrument Your Function [#instrument]
 
-First add the [OpenTelemetry SDK for AWS Lambda](https://www.nuget.org/packages/OpenTelemetry.Instrumentation.AWSLambda/), as well as the [OTLP exporter package](https://www.nuget.org/packages/OpenTelemetry.Exporter.OpenTelemetryProtocol). You can add more OpenTelemetry packages such as [OpenTelemetry.Instrumentation.AWS](https://www.nuget.org/packages/OpenTelemetry.Instrumentation.AWS) and [OpenTelemetry.Instrumentation.Http](https://www.nuget.org/packages/OpenTelemetry.Instrumentation.Http).
+First add the [OpenTelemetry SDK for AWS Lambda](https://www.nuget.org/packages/OpenTelemetry.Instrumentation.AWSLambda/), as well as the [OTLP exporter package](https://www.nuget.org/packages/OpenTelemetry.Exporter.OpenTelemetryProtocol). You can add more OpenTelemetry instrumentation packages, such as [OpenTelemetry.Instrumentation.AWS](https://www.nuget.org/packages/OpenTelemetry.Instrumentation.AWS) and [OpenTelemetry.Instrumentation.Http](https://www.nuget.org/packages/OpenTelemetry.Instrumentation.Http), to get additional visibility into your function's behavior.
 
 ```bash
 dotnet add package OpenTelemetry.Instrumentation.AWSLambda
@@ -193,7 +193,7 @@ TracerProvider tracerProvider = Sdk.CreateTracerProviderBuilder()
 ```
 
 <Callout variant="important">
-  Be sure to `DisableAwsXRayContextExtraction` property set to `true` if you don't enable X-Ray. Otherwise, traces will not be instrumented.
+  Be sure to set the `DisableAwsXRayContextExtraction` property to `true` if you don't enable X-Ray. Otherwise, traces will not be instrumented.
 </Callout>
 
 Create a wrapper function with the same signature as the original Lambda handler function. Call `AWSLambdaWrapper.Trace()` API and pass `TracerProvider`, the original Lambda function, and its inputs as parameters.
@@ -208,7 +208,7 @@ public string OriginalFunctionHandler(JObject input, ILambdaContext context) {
 }
 ```
 
-If an original handler is an async function, you can use `TraceAsync()` API instead of `TraceAsync()`.
+If your original handler is an async function, use the `TraceAsync()` API instead of `Trace()`.
 
 ```csharp
 public Task<APIGatewayProxyResponse> TracingFunctionHandler(APIGatewayProxyRequest request,


### PR DESCRIPTION
I found a few issues and this PR into your `patch-7` branch fixes them:

* There was one place where you said `TraceAsync()` where I'm pretty sure you meant to say `Trace()`
* We prefer `.NET 6` to `dotnet6` to refer to the .NET 6 runtime/framework
* General grammar/wording issues